### PR TITLE
Make `input` take a block instead of directly a type

### DIFF
--- a/lib/apigen/formats/openapi.rb
+++ b/lib/apigen/formats/openapi.rb
@@ -52,7 +52,7 @@ module Apigen
                 'parameters' => parameters,
                 'responses' => responses
               }
-              operation['requestBody'] = input(api, endpoint.input) if endpoint.input
+              operation['requestBody'] = input(api, endpoint.input.type) if endpoint.input
               hash[endpoint.path] ||= {}
               hash[endpoint.path][endpoint.method.to_s] = operation
             end

--- a/lib/apigen/formats/swagger.rb
+++ b/lib/apigen/formats/swagger.rb
@@ -50,7 +50,7 @@ module Apigen
               parameters = []
               parameters.concat(endpoint.path_parameters.properties.map { |name, type| path_parameter(api, name, type) })
               parameters.concat(endpoint.query_parameters.properties.map { |name, type| query_parameter(api, name, type) })
-              parameters << input_parameter(api, endpoint.input) if endpoint.input
+              parameters << input_parameter(api, endpoint.input.type) if endpoint.input
               responses = endpoint.outputs.map { |output| response(api, output) }.to_h
               hash[endpoint.path] ||= {}
               hash[endpoint.path][endpoint.method.to_s] = {

--- a/spec/apigen/formats/example.rb
+++ b/spec/apigen/formats/example.rb
@@ -26,11 +26,13 @@ module Apigen
     api.endpoint :create_user do
       method :post
       path '/users'
-      input :object do
-        name :string
-        email :string
-        password :string
-        captcha :string
+      input do
+        type :object do
+          name :string
+          email :string
+          password :string
+          captcha :string
+        end
       end
       output :success do
         status 200
@@ -47,11 +49,13 @@ module Apigen
       path '/users/{id}' do
         id :string
       end
-      input :object do
-        name :string?
-        email :string?
-        password :string?
-        captcha :string
+      input do
+        type :object do
+          name :string?
+          email :string?
+          password :string?
+          captcha :string
+        end
       end
       output :success do
         status 200

--- a/spec/apigen/rest_spec.rb
+++ b/spec/apigen/rest_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Apigen::Rest do
           end
         end
       end
-    end.to raise_error 'Use `input :typename` to assign an input type to :create_user.'
+    end.to raise_error 'Use `input { type :typename }` to assign an input type to :create_user.'
   end
 
   it 'requires input for PUT endpoints' do
@@ -49,7 +49,7 @@ RSpec.describe Apigen::Rest do
           end
         end
       end
-    end.to raise_error 'Use `input :typename` to assign an input type to :update_user.'
+    end.to raise_error 'Use `input { type :typename }` to assign an input type to :update_user.'
   end
 
   it 'rejects input for GET endpoints' do
@@ -60,7 +60,9 @@ RSpec.describe Apigen::Rest do
           path '/users/{id}' do
             id :string
           end
-          input :string
+          input do
+            type :string
+          end
           output :success do
             status 200
             type :string
@@ -78,7 +80,9 @@ RSpec.describe Apigen::Rest do
           path '/users/{id}' do
             id :string
           end
-          input :string
+          input do
+            type :string
+          end
           output :success do
             status 200
             type :string
@@ -94,7 +98,9 @@ RSpec.describe Apigen::Rest do
         endpoint :create_user do
           method :post
           path '/users'
-          input :user
+          input do
+            type :user
+          end
           output :success do
             status 200
             type :string
@@ -116,7 +122,9 @@ RSpec.describe Apigen::Rest do
         endpoint :wrong_method do
           method :abc
           path '/users'
-          input :user
+          input do
+            type :user
+          end
           output :success do
             status 200
             type :string
@@ -132,7 +140,9 @@ RSpec.describe Apigen::Rest do
         endpoint :create_user do
           method :post
           path '/users'
-          input :missing
+          input do
+            type :missing
+          end
           output :success do
             status 200
             type :string
@@ -148,7 +158,9 @@ RSpec.describe Apigen::Rest do
         endpoint :create_user do
           method :post
           path '/users'
-          input :void
+          input do
+            type :void
+          end
           output :success do
             status 200
             type :missing


### PR DESCRIPTION
This will allow the addition of descriptions and examples later on.